### PR TITLE
Add default case for switch statements

### DIFF
--- a/quarkus/product/src/main/java/org/jnd/microservices/quarkus/product/model/ProductType.java
+++ b/quarkus/product/src/main/java/org/jnd/microservices/quarkus/product/model/ProductType.java
@@ -14,6 +14,10 @@ public enum ProductType {
                 return "gadgets";
             case CLOTHES:
                 return "clothes";
+            //missing default case
+            default:
+               // add default case
+                break;
         }
         return null;
     }


### PR DESCRIPTION
According to CWE, not having a default case for switch statements in code is a security weakness. See https://cwe.mitre.org/data/definitions/478.html