### PR TITLE
Add default case for switch statements

### DIFF
--- a/src/data-model/src/main/java/org/jnd/microservices/model/ProductType.java
+++ b/src/data-model/src/main/java/org/jnd/microservices/model/ProductType.java
@@ -14,6 +14,10 @@ public enum ProductType {
                 return "gadgets";
             case CLOTHES:
                 return "clothes";
+            //missing default case
+            default:
+                // add default case
+                break;
         }
         return null;
     }


### PR DESCRIPTION
According to CWE, not having a default case for switch statements in code is a security weakness. See https://cwe.mitre.org/data/definitions/478.html